### PR TITLE
Update got and retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "got": "^4.1.1",
+    "got": "^6.3.0",
     "is-plain-obj": "^1.0.0",
     "is-stream": "^1.0.1",
     "object-assign": "^3.0.0",
     "pinkie-promise": "^1.0.0",
-    "retry": "^0.6.1"
+    "retry": "^0.10.0"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
I'd love to use this package in [pnpm](https://github.com/rstacruz/pnpm/issues/317) but the dependencies are out of date.

Could you please update got and retry and publish a new version of got-retry?